### PR TITLE
added: `count_slot` for `HubstorageClient`

### DIFF
--- a/hubstorage/frontier.py
+++ b/hubstorage/frontier.py
@@ -59,6 +59,9 @@ class Frontier(ResourceType):
             params['mincount'] = mincount
         return self.apiget((frontier, 's', slot, 'q'), params=params)
 
+    def count_slot(self, frontier, slot):
+        return self.apiget((frontier, 's', slot, 'q/count'))
+
     def delete(self, frontier, slot, ids):
         self.apipost((frontier, 's', slot, 'q/deleted'), jl=ids)
 

--- a/tests/test_frontier.py
+++ b/tests/test_frontier.py
@@ -24,7 +24,7 @@ class FrontierTest(HSTestCase):
     def _get_urls(self, batch):
         return [r[0] for r in batch['requests']]
 
-    def test_add_read(self):
+    def test_add_read_count(self):
         frontier = self.project.frontier
 
         fps = [{'fp': '/'}]
@@ -37,6 +37,9 @@ class FrontierTest(HSTestCase):
                 in frontier.read(self.frontier, self.slot)]
         expected_urls = [[u'/', u'/index.html', u'/index2.html']]
         self.assertEqual(urls, expected_urls)
+
+        count = [x['count'] for x in frontier.count_slot(self.frontier, self.slot)]
+        self.assertEqual(count, [len(expected_urls[0])])
 
     def test_add_multiple_chunks(self):
         frontier = self.project.frontier


### PR DESCRIPTION
Using method `q/count` from https://github.com/scrapinghub/hubstorage/blob/master/servlet/src/main/webapp/hstorage/apis/frontier/api.py#L37