### PR TITLE
show error message when push fails

### DIFF
--- a/hubstorage/jobq.py
+++ b/hubstorage/jobq.py
@@ -23,10 +23,10 @@ class JobQ(ResourceType):
                 if 'error' in o:
                     if 'Active job' in o['error']:
                         raise DuplicateJobError()
-                    raise HTTPError()
+                    raise HTTPError(o['error'])
                 return o
         except HTTPError as exc:
-            if exc.response.status_code == 409:
+            if exc.response and exc.response.status_code == 409:
                 raise DuplicateJobError()
             raise
 


### PR DESCRIPTION
This change will show the error message from the request in the traceback, and doesn't assume a status code is available (which seems it may be the case with new jobq).

Before the change, I got the following error:

```
  File "hubstorage/jobq.py", line 29, in push
    if exc.response.status_code == 409:
AttributeError: 'NoneType' object has no attribute 'status_code'
```

After:

```
  File "hubstorage/jobq.py", line 26, in push
    raise HTTPError(o['error'])
requests.exceptions.HTTPError: job must contain a spider
```