### PR TITLE
batchuploader: include beginning of overly big items in error msg

### DIFF
--- a/hubstorage/batchuploader.py
+++ b/hubstorage/batchuploader.py
@@ -189,6 +189,8 @@ class ValueTooLarge(ValueError):
 
 
 class _BatchWriter(object):
+    #: Truncate overly big items to that many bytes for the error message.
+    ERRMSG_DATA_TRUNCATION_LEN = 1024
 
     def __init__(self, url, start, auth, size, interval, qsize,
                  maxitemsize, content_encoding, uploader, callback=None):
@@ -211,8 +213,10 @@ class _BatchWriter(object):
         assert not self.closed, 'attempting writes to a closed writer'
         data = jsonencode(item)
         if len(data) > self.maxitemsize:
-            raise ValueTooLarge('value exceeds max encoded size of {} bytes'\
-                                .format(self.maxitemsize))
+            truncated_data = data[:self.ERRMSG_DATA_TRUNCATION_LEN] + "..."
+            raise ValueTooLarge(
+                'Value exceeds max encoded size of {} bytes: {!r}'
+                .format(self.maxitemsize, truncated_data))
 
         self.itemsq.put(data)
         if self.itemsq.full():

--- a/tests/test_batchuploader.py
+++ b/tests/test_batchuploader.py
@@ -33,9 +33,21 @@ class BatchUploaderTest(HSTestCase):
     def test_writer_maxitemsize(self):
         job, w = self._job_and_writer()
         m = w.maxitemsize
-        self.assertRaises(ValueTooLarge, w.write, {'b': 'x' * m})
-        self.assertRaises(ValueTooLarge, w.write, {'b'*m: 'x'})
-        self.assertRaises(ValueTooLarge, w.write, {'b'*(m/2): 'x'*(m/2)})
+        self.assertRaisesRegexp(
+            ValueTooLarge,
+            'Value exceeds max encoded size of 1048576 bytes:'
+            ' \'{"b": "x+\\.\\.\\.\'',
+            w.write, {'b': 'x' * m})
+        self.assertRaisesRegexp(
+            ValueTooLarge,
+            'Value exceeds max encoded size of 1048576 bytes:'
+            ' \'{"b+\\.\\.\\.\'',
+            w.write, {'b'*m: 'x'})
+        self.assertRaisesRegexp(
+            ValueTooLarge,
+            'Value exceeds max encoded size of 1048576 bytes:'
+            ' \'{"b+\\.\\.\\.\'',
+            w.write, {'b'*(m/2): 'x'*(m/2)})
 
     def test_writer_contentencoding(self):
         for ce in ('identity', 'gzip'):


### PR DESCRIPTION
Right now the message is rather uninformative and doesn't help debugging the failure, because batchuploader's tracebacks focus on logger code not user code.