### PR TITLE
Pass testsuite and pair functionality with service

### DIFF
--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -67,7 +67,7 @@ class HubstorageClient(object):
         jobdata = jobq.start(**startparams)
         if jobdata:
             jobkey = jobdata.pop('key')
-            jobauth = (jobkey, jobdata['auth'])
+            jobauth = (jobkey, jobdata.pop('auth'))
             return self.get_job(jobkey, jobauth=jobauth, metadata=jobdata)
 
     def get_project(self, *args, **kwargs):

--- a/hubstorage/job.py
+++ b/hubstorage/job.py
@@ -9,10 +9,10 @@ class Job(object):
 
     def __init__(self, client, key, auth=None, jobauth=None, metadata=None):
         self.key = urlpathjoin(key)
-        assert len(self.key.split('/')) == 3, 'Jobkey must be projectid/spiderid/jobid: %s' % self.key
-        self._jobauth = jobauth
-        # It can't use self.jobauth because metadata is not ready yet
-        self.auth = jobauth or auth
+        assert len(self.key.split('/')) == 3, \
+            'Jobkey must be projectid/spiderid/jobid: %s' % self.key
+        self.jobauth = jobauth
+        self.auth = self.jobauth or auth
         self.metadata = JobMeta(client, self.key, self.auth, cached=metadata)
         self.items = Items(client, self.key, self.auth)
         self.logs = Logs(client, self.key, self.auth)
@@ -28,13 +28,6 @@ class Job(object):
         # now wait for all writers to close together
         for w in wl:
             w.close(block=True)
-
-    @property
-    def jobauth(self):
-        if self._jobauth is None:
-            token = self.metadata.authtoken()
-            self._jobauth = (self.key, token)
-        return self._jobauth
 
     def _update_metadata(self, *args, **kwargs):
         self.metadata.update(*args, **kwargs)

--- a/hubstorage/jobq.py
+++ b/hubstorage/jobq.py
@@ -42,8 +42,13 @@ class JobQ(ResourceType):
         r = list(self.apiget((spiderid, 'summary', _queuename), params=params))
         return (r and r[0] or None) if _queuename else r
 
-    def list(self, count=None, stop=None, startts=None, endts=None):
+    def list(self, spider=None, count=None, stop=None, state=None,
+             startts=None, endts=None):
         params = {}
+        if state is not None:
+            params['state'] = state
+        if spider is not None:
+            params['spider'] = spider
         if count is not None:
             params['count'] = count
         if stop is not None:

--- a/hubstorage/project.py
+++ b/hubstorage/project.py
@@ -42,16 +42,15 @@ class Project(object):
         kwargs.setdefault('auth', self.auth)
         return self.client.get_job(key, *args, **kwargs)
 
-    def get_jobs(self, _key=None, **kwargs):
-        for metadata in self.jobs.list(_key, meta='_key', **kwargs):
-            key = metadata.pop('_key')
+    def get_jobs(self, **kwargs):
+        for metadata in self.jobq.list(**kwargs):
+            key = metadata.pop('key')
             yield self.get_job(key, metadata=metadata)
 
     def push_job(self, spidername, **jobparams):
         data = self.jobq.push(spidername, **jobparams)
         key = data['key']
-        jobauth = (key, data['auth'])
-        return Job(self.client, key, auth=self.auth, jobauth=jobauth)
+        return Job(self.client, key, auth=self.auth)
 
     def start_job(self, **startparams):
         return self.client.start_job(projectid=self.projectid, auth=self.auth,

--- a/tests/hstestcase.py
+++ b/tests/hstestcase.py
@@ -51,10 +51,6 @@ class HSTestCase(unittest.TestCase):
                 for summary in info['summary']:
                     cls._remove_job(summary['key'])
 
-        # Cleanup jobs created directly with jobsmeta instead of jobq
-        for job in project.get_jobs():
-            cls._delete_job(job.key)
-
     @classmethod
     def _remove_job(cls, jobkey):
         cls.project.jobq.delete(jobkey)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,26 +9,31 @@ from hubstorage.utils import millitime, apipoll
 class ClientTest(HSTestCase):
 
     def test_connect_retry(self):
-        c = HubstorageClient(auth=self.auth,
-            endpoint=self.endpoint, max_retries=2)
-        job = c.push_job(self.projectid, self.spidername,
-                         state='running')
+        c = HubstorageClient(auth=self.auth, endpoint=self.endpoint,
+                             max_retries=2)
+        c.push_job(self.projectid, self.spidername)
+        job = c.start_job(projectid=self.projectid)
         m = job.metadata
-        self.assertEqual(m.get('state'), u'running', c.auth)
+        self.assertEqual(m.get('state'), u'running', dict(m))
         m.expire()
-        self.assertEqual(c.session.adapters['http://'].max_retries, 2)
+        retries = c.session.adapters['http://'].max_retries
+        if not isinstance(retries, int):
+            retries = retries.total
+        self.assertEqual(retries, 2)
 
     def test_push_job(self):
         c = self.hsclient
-        job = c.push_job(self.projectid, self.spidername,
-                         state='running',
-                         priority=self.project.jobq.PRIO_LOW,
-                         foo='baz')
+        c.push_job(self.projectid, self.spidername,
+                   priority=self.project.jobq.PRIO_LOW,
+                   foo='baz')
+        job = c.start_job(projectid=self.projectid)
         m = job.metadata
         self.assertEqual(m.get('state'), u'running', c.auth)
         self.assertEqual(m.get('foo'), u'baz')
         self.project.jobq.delete(job)
-        m.expire()
+
+        # job auth token is valid only while job is running
+        m = c.get_job(job.key).metadata
         self.assertEqual(m.get('state'), u'deleted')
         self.assertEqual(m.get('foo'), u'baz')
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -37,10 +37,10 @@ class ProjectTest(HSTestCase):
         j2 = p.push_job(self.spidername, testid=1)
         j3 = p.push_job(self.spidername, testid=2)
         # global list must list at least one job
-        self.assertTrue(list(p.get_jobs(count=1)))
+        self.assertTrue(list(p.get_jobs(count=1, state='pending')))
         # List all jobs for test spider
-        r = list(p.get_jobs(self.spiderid))
-        self.assertEqual([j.key for j in r], [j1.key, j2.key, j3.key])
+        r = list(p.get_jobs(spider=self.spidername, state='pending'))
+        self.assertEqual([j.key for j in r], [j3.key, j2.key, j1.key])
 
     def test_push_job(self):
         job = self.project.push_job(self.spidername, state='running',
@@ -112,7 +112,6 @@ class ProjectTest(HSTestCase):
         jobauth = job.auth
         del job
 
-        self.assertTrue(list(project.jobs.list(self.spiderid, count=1)))
         self.assertTrue(list(project.items.list(self.spiderid, count=1)))
         self.assertTrue(list(project.logs.list(self.spiderid, count=1)))
         self.assertTrue(list(project.samples.list(self.spiderid, count=1)))
@@ -126,14 +125,14 @@ class ProjectTest(HSTestCase):
         settings.pop('botgroups', None)  # ignore testsuite botgroups
         self.assertEqual(settings, {})
         project.settings['created'] = created = millitime()
-        project.settings['botgroups'] = ['g1', 'g2']
+        project.settings['botgroups'] = ['g1']
         project.settings.save()
         self.assertEqual(project.settings.liveget('created'), created)
-        self.assertEqual(project.settings.liveget('botgroups'), ['g1', 'g2'])
+        self.assertEqual(project.settings.liveget('botgroups'), ['g1'])
         project.settings.expire()
         self.assertEqual(dict(project.settings), {
             'created': created,
-            'botgroups': ['g1', 'g2'],
+            'botgroups': ['g1'],
         })
 
     def test_requests(self):


### PR DESCRIPTION
Alternative to #36 in order to fix #35 

/cc @torymur 

List of compromises:

- JobQ doesn't support multiple botgroups per project anymore
- /jobs/ endpoint doesn't support scanning anymore and now relies on
  /jobq/NNN/list which return jobs in reverse order and doesn't mix
  jobs from multiples states unless `state` param is used
- job auth token is only returned when job is moved from pending to
  running queue, that's when calling /jobq/startjob. The token is not
  stored anymore as job metadata.
- HubstorageClient.get_jobs() changed it signature and doesn't accept
  numerical spiderid as first argument anymore, only spider by its name.

```
$ py.test -x --ff
======================================== test session starts ====================================
platform darwin -- Python 2.7.10, pytest-2.8.2, py-1.4.30, pluggy-0.3.1
run-last-failure: run all (no recorded failures)
rootdir: /Users/daniel/src/python-hubstorage, inifile:
plugins: capturelog-0.7
collected 53 items

tests/test_activity.py ...
tests/test_batchuploader.py ....
tests/test_client.py ......
tests/test_collections.py ..
tests/test_frontier.py ....
tests/test_jobq.py sx...............
tests/test_jobsmeta.py ...
tests/test_project.py ...........
tests/test_system.py ...

=============== 51 passed, 1 skipped, 1 xfailed, 1 pytest-warnings in 173.62 seconds ============
```