### PR TITLE
Deprecate list method from Jobs class

### DIFF
--- a/hubstorage/project.py
+++ b/hubstorage/project.py
@@ -70,7 +70,9 @@ class Jobs(ResourceType):
     resource_type = 'jobs'
 
     def list(self, _key=None, **params):
-        return self.apiget(_key, params=params)
+        warnings.warn('Method `jobs.list()` is deprecated, '
+                      'use `project.jobq.list()` instead', Warning)
+        return self.client.get_project(_key).jobq.list(**params)
 
 class Items(ResourceType):
 


### PR DESCRIPTION
`/jobs/` end point no longer supports scanning, so it seems reasonable to deprecate the `list()` method of `Jobs` class.

Related to #38.
