### PR TITLE
Retry when safe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,3 +52,10 @@ Example getting job data later::
     [{'title': 'my first item'}]
 
     ...
+
+
+Testing
+-------
+
+Running the tests require the hubstorage backend to be running,
+and the python `responses` library (see `tox.ini`).

--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -47,14 +47,14 @@ class HubstorageClient(object):
         self.root = ResourceType(self, None)
         self._batchuploader = None
 
-    def request_idempotent(self, *args, **kwargs):
+    def request_idempotent(self, **kwargs):
         """
         Execute an HTTP request with the current client session.
 
         Use the retry policy configured in the client.
         """
         def invoke_req():
-            r = self.session.request(*args, **kwargs)
+            r = self.session.request(**kwargs)
 
             if not r.ok:
                 logger.debug('%s: %s', r, r.content)
@@ -63,13 +63,13 @@ class HubstorageClient(object):
 
         return self.retrier.call(invoke_req)
 
-    def request_nonidempotent(self, *args, **kwargs):
+    def request_nonidempotent(self, **kwargs):
         """
         Execute an HTTP request with the current client session
 
         Do not use the retry policy to avoid side-effects.
         """
-        r = self.session.request(*args, **kwargs)
+        r = self.session.request(**kwargs)
 
         if not r.ok:
             logger.debug('%s: %s', r, r.content)

--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -86,6 +86,7 @@ class HubstorageClient(object):
 
         Use the retry policy configured in the client when is_idempotent is True
         """
+        kwargs.setdefault('timeout', self.connection_timeout)
 
         def invoke_request():
             r = self.session.request(**kwargs)

--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -19,12 +19,12 @@ __version__ = pkgutil.get_data('hubstorage', 'VERSION').strip()
 
 logger = logging.getLogger('HubstorageClient')
 
-_ERROR_CODES_TO_RETRY = (429, 503, 504)
+_HTTP_ERROR_CODES_TO_RETRY = (408, 429, 503, 504)
 
 
 def _hc_retry_on_exception(err):
     """Callback used by the client to restrict the retry to acceptable errors"""
-    if (isinstance(err, HTTPError) and err.response.status_code in _ERROR_CODES_TO_RETRY):
+    if (isinstance(err, HTTPError) and err.response.status_code in _HTTP_ERROR_CODES_TO_RETRY):
         logger.warning("Server failed with %d status code, retrying (maybe)" % (err.response.status_code,))
         return True
 

--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -28,6 +28,7 @@ def _hc_retry_on_exception(err):
         logger.warning("Server failed with %d status code, retrying (maybe)" % (err.response.status_code,))
         return True
 
+    # TODO: python3 compatibility: BadStatusLine error are wrapped differently
     if (isinstance(err, ConnectionError) and err.args[0] == 'Connection aborted.' and
             isinstance(err.args[1], BadStatusLine) and err.args[1][0] == repr('')):
         logger.warning("Protocol failed with BadStatusLine, retrying (maybe)")

--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -4,7 +4,7 @@ High level Hubstorage client
 from httplib import BadStatusLine
 import logging
 import pkgutil
-from requests import session, adapters, HTTPError, ConnectionError
+from requests import session, adapters, HTTPError, ConnectionError, Timeout
 from retrying import Retrying
 from .utils import xauth, urlpathjoin
 from .project import Project
@@ -32,6 +32,10 @@ def _hc_retry_on_exception(err):
     if (isinstance(err, ConnectionError) and err.args[0] == 'Connection aborted.' and
             isinstance(err.args[1], BadStatusLine) and err.args[1][0] == repr('')):
         logger.warning("Protocol failed with BadStatusLine, retrying (maybe)")
+        return True
+
+    if isinstance(err, Timeout):
+        logger.warning("Server connection timeout, retrying (maybe)")
         return True
 
     return False

--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -25,18 +25,14 @@ class HubstorageClient(object):
         self.auth = xauth(auth)
         self.endpoint = endpoint or self.DEFAULT_ENDPOINT
         self.connection_timeout = connection_timeout or self.DEFAULT_TIMEOUT
-        self.session = self._create_session(max_retries)
+        self.session = self._create_session()
         self.jobq = JobQ(self, None)
         self.projects = Projects(self, None)
         self.root = ResourceType(self, None)
         self._batchuploader = None
 
-    def _create_session(self, max_retries):
+    def _create_session(self):
         s = session()
-        if max_retries > 0:
-            a = adapters.HTTPAdapter(max_retries=max_retries)
-            s.mount('http://', a)
-            s.mount('https://', a)
         s.headers.update({'User-Agent': self.USERAGENT})
         return s
 

--- a/hubstorage/collectionsrt.py
+++ b/hubstorage/collectionsrt.py
@@ -21,7 +21,7 @@ class Collections(DownloadableResource):
 
     def set(self, _type, _name, _values):
         try:
-            return self.apipost((_type, _name), jl=_values)
+            return self.apipost((_type, _name), is_idempotent=True, jl=_values)
         except HTTPError as exc:
             if exc.response.status_code in (400, 413):
                 raise ValueError(exc.response.text)
@@ -29,7 +29,7 @@ class Collections(DownloadableResource):
                 raise
 
     def delete(self, _type, _name, _keys):
-        return self.apipost((_type, _name, 'deleted'), jl=_keys)
+        return self.apipost((_type, _name, 'deleted'), is_idempotent=True, jl=_keys)
 
     def iter_json(self, _type, _name, requests_params=None, **apiparams):
         return DownloadableResource.iter_json(self, (_type, _name),

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -19,12 +19,19 @@ class ResourceType(object):
         self.url = urlpathjoin(client.endpoint, self.key)
 
     def _iter_lines(self, _path, **kwargs):
+        is_idempotent = kwargs.get('is_idempotent', False) or kwargs['method'] == 'GET'
+
         kwargs['url'] = urlpathjoin(self.url, _path)
         kwargs.setdefault('auth', self.auth)
         kwargs.setdefault('timeout', self.client.connection_timeout)
         if 'jl' in kwargs:
             kwargs['data'] = jlencode(kwargs.pop('jl'))
-        r = self.client.request(**kwargs)
+
+        if is_idempotent:
+            r = self.client.request_idempotent(**kwargs)
+        else:
+            r = self.client.request_nonidempotent(**kwargs)
+
         return r.iter_lines()
 
     def apirequest(self, _path=None, **kwargs):

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -44,7 +44,7 @@ class ResourceType(object):
         return self.apirequest(_path, method='GET', **kwargs)
 
     def apidelete(self, _path=None, **kwargs):
-        return self.apirequest(_path, method='DELETE', **kwargs)
+        return self.apirequest(_path, method='DELETE', is_idempotent=True, **kwargs)
 
 
 class DownloadableResource(ResourceType):

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -19,18 +19,13 @@ class ResourceType(object):
         self.url = urlpathjoin(client.endpoint, self.key)
 
     def _iter_lines(self, _path, **kwargs):
-        is_idempotent = kwargs.pop('is_idempotent', False) or kwargs['method'] == 'GET'
-
         kwargs['url'] = urlpathjoin(self.url, _path)
         kwargs.setdefault('auth', self.auth)
         kwargs.setdefault('timeout', self.client.connection_timeout)
         if 'jl' in kwargs:
             kwargs['data'] = jlencode(kwargs.pop('jl'))
 
-        if is_idempotent:
-            r = self.client.request_idempotent(**kwargs)
-        else:
-            r = self.client.request_nonidempotent(**kwargs)
+        r = self.client.request(**kwargs)
 
         return r.iter_lines()
 
@@ -41,6 +36,7 @@ class ResourceType(object):
         return self.apirequest(_path, method='POST', **kwargs)
 
     def apiget(self, _path=None, **kwargs):
+        kwargs.setdefault('is_idempotent', True)
         return self.apirequest(_path, method='GET', **kwargs)
 
     def apidelete(self, _path=None, **kwargs):

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -19,7 +19,7 @@ class ResourceType(object):
         self.url = urlpathjoin(client.endpoint, self.key)
 
     def _iter_lines(self, _path, **kwargs):
-        is_idempotent = kwargs.get('is_idempotent', False) or kwargs['method'] == 'GET'
+        is_idempotent = kwargs.pop('is_idempotent', False) or kwargs['method'] == 'GET'
 
         kwargs['url'] = urlpathjoin(self.url, _path)
         kwargs.setdefault('auth', self.auth)
@@ -190,10 +190,11 @@ class MappingResourceType(ResourceType, MutableMapping):
         self._deleted.clear()
         if self._cached:
             if not self.ignore_fields:
-                self.apipost(jl=self._data)
+                self.apipost(jl=self._data, is_idempotent=True)
             else:
                 self.apipost(jl=dict((k, v) for k, v in self._data.iteritems()
-                                     if k not in self.ignore_fields))
+                                     if k not in self.ignore_fields),
+                             is_idempotent=True)
 
     def __getitem__(self, key):
         return self._data[key]

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -21,7 +21,6 @@ class ResourceType(object):
     def _iter_lines(self, _path, **kwargs):
         kwargs['url'] = urlpathjoin(self.url, _path)
         kwargs.setdefault('auth', self.auth)
-        kwargs.setdefault('timeout', self.client.connection_timeout)
         if 'jl' in kwargs:
             kwargs['data'] = jlencode(kwargs.pop('jl'))
 

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -44,7 +44,8 @@ class ResourceType(object):
         return self.apirequest(_path, method='GET', **kwargs)
 
     def apidelete(self, _path=None, **kwargs):
-        return self.apirequest(_path, method='DELETE', is_idempotent=True, **kwargs)
+        kwargs.setdefault('is_idempotent', True)
+        return self.apirequest(_path, method='DELETE', **kwargs)
 
 
 class DownloadableResource(ResourceType):

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -24,10 +24,7 @@ class ResourceType(object):
         kwargs.setdefault('timeout', self.client.connection_timeout)
         if 'jl' in kwargs:
             kwargs['data'] = jlencode(kwargs.pop('jl'))
-        r = self.client.session.request(**kwargs)
-        if not r.ok:
-            logger.debug('%s: %s', r, r.content)
-        r.raise_for_status()
+        r = self.client.request(**kwargs)
         return r.iter_lines()
 
     def apirequest(self, _path=None, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=1.0
+retrying==1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=1.0
-retrying==1.3.3
+retrying>=1.3.3

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,19 +8,6 @@ from hubstorage.utils import millitime, apipoll
 
 class ClientTest(HSTestCase):
 
-    def test_connect_retry(self):
-        c = HubstorageClient(auth=self.auth, endpoint=self.endpoint,
-                             max_retries=2)
-        c.push_job(self.projectid, self.spidername)
-        job = c.start_job(projectid=self.projectid)
-        m = job.metadata
-        self.assertEqual(m.get('state'), u'running', dict(m))
-        m.expire()
-        retries = c.session.adapters['http://'].max_retries
-        if not isinstance(retries, int):
-            retries = retries.total
-        self.assertEqual(retries, 2)
-
     def test_push_job(self):
         c = self.hsclient
         c.push_job(self.projectid, self.spidername,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,47 +1,10 @@
 """
 Test Client
 """
-import requests
 from hstestcase import HSTestCase
-from hubstorage import HubstorageClient
 from hubstorage.utils import millitime, apipoll
-import responses
-import json
-import re
 
 class ClientTest(HSTestCase):
-
-    @responses.activate
-    def test_retry_get_job(self):
-        # Prepare
-        client = HubstorageClient(auth=self.auth, endpoint=self.endpoint, max_retries=3)
-        job_metadata = {'project': self.projectid, 'spider': self.spidername, 'state': 'pending'}
-
-        # setup connector that fails on 2 calls
-        attempts = [0]  # use a list for nonlocal mutability used in request_callback
-        def request_callback(request):
-            attempts[0] += 1
-
-            print request, attempts
-
-            if attempts[0] < 3:
-                return (504, {}, "Timeout")
-            else:
-                resp_body = dict(job_metadata)
-                return (200, {}, json.dumps(resp_body))
-
-        responses.add_callback(
-            responses.GET, re.compile(self.endpoint + '/.*'),
-            callback=request_callback,
-            content_type='application/json',
-        )
-
-        # Act
-        job2 = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
-
-        # Assert
-        self.assertEqual(dict(job_metadata), dict(job2.metadata))
-        self.assertEqual(attempts[0], 3)
 
     def test_push_job(self):
         c = self.hsclient

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,47 @@
 """
 Test Client
 """
+import requests
 from hstestcase import HSTestCase
 from hubstorage import HubstorageClient
 from hubstorage.utils import millitime, apipoll
-
+import responses
+import json
+import re
 
 class ClientTest(HSTestCase):
+
+    @responses.activate
+    def test_retry_get_job(self):
+        # Prepare
+        client = HubstorageClient(auth=self.auth, endpoint=self.endpoint, max_retries=3)
+        job_metadata = {'project': self.projectid, 'spider': self.spidername, 'state': 'pending'}
+
+        # setup connector that fails on 2 calls
+        attempts = [0]  # use a list for nonlocal mutability used in request_callback
+        def request_callback(request):
+            attempts[0] += 1
+
+            print request, attempts
+
+            if attempts[0] < 3:
+                return (504, {}, "Timeout")
+            else:
+                resp_body = dict(job_metadata)
+                return (200, {}, json.dumps(resp_body))
+
+        responses.add_callback(
+            responses.GET, re.compile(self.endpoint + '/.*'),
+            callback=request_callback,
+            content_type='application/json',
+        )
+
+        # Act
+        job2 = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
+
+        # Assert
+        self.assertEqual(dict(job_metadata), dict(job2.metadata))
+        self.assertEqual(attempts[0], 3)
 
     def test_push_job(self):
         c = self.hsclient

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,41 @@
+"""
+Test Retry Policy
+"""
+from hstestcase import HSTestCase
+from hubstorage import HubstorageClient
+import responses
+import json
+import re
+
+
+class RetryTest(HSTestCase):
+    @responses.activate
+    def test_retry_get_job(self):
+        # Prepare
+        client = HubstorageClient(auth=self.auth, endpoint=self.endpoint, max_retries=3)
+        job_metadata = {'project': self.projectid, 'spider': self.spidername, 'state': 'pending'}
+
+        # setup connector that fails on 2 calls
+        attempts = [0]  # use a list for nonlocal mutability used in request_callback
+
+        def request_callback(request):
+            attempts[0] += 1
+
+            if attempts[0] < 3:
+                return (504, {}, "Timeout")
+            else:
+                resp_body = dict(job_metadata)
+                return (200, {}, json.dumps(resp_body))
+
+        responses.add_callback(
+            responses.GET, re.compile(self.endpoint + '/.*'),
+            callback=request_callback,
+            content_type='application/json',
+        )
+
+        # Act
+        job2 = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
+
+        # Assert
+        self.assertEqual(dict(job_metadata), dict(job2.metadata))
+        self.assertEqual(attempts[0], 3)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -20,17 +20,22 @@ class RetryTest(HSTestCase):
         #       Thus the retry policy does not catch 404 errors when retrying deletes (simplify implementation A LOT).
         #       This test checks that this assumption holds.
 
-        # Check frontier delete
         client = HubstorageClient(auth=self.auth, endpoint=self.endpoint, max_retries=0)
-
         project = client.get_project(projectid=self.projectid)
-        result = project.frontier.delete_slot('frontier_non_existing', 'slot_non_existing')
+
+        # Check frontier delete
+        project.frontier.delete_slot('frontier_non_existing', 'slot_non_existing')
 
         # Check metadata delete
         job = client.push_job(self.projectid, self.spidername)
         job.metadata['foo'] = 'bar'  # Add then delete key, this will trigger an api delete for item foo
         del job.metadata['foo']
         job.metadata.save()
+
+        # Check collections delete
+        store = project.collections.new_store('foo')
+        store.set({'_key': 'foo'})
+        store.delete('bar')
 
         self.assertTrue(True, "No error have been triggered by calling a delete on resources that do not exist")
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -123,15 +123,12 @@ class RetryTest(HSTestCase):
         self.mock_api(method=DELETE, callback=callback_delete)
 
         # Act
-        err = None
-
         job = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
         job.metadata['foo'] = 'bar'
         del job.metadata['foo']
         job.metadata.save()
 
         # Assert
-        self.assertIsNone(err, None)
         self.assertEqual(attempts_count_delete[0], 3)
 
     @responses.activate
@@ -146,14 +143,11 @@ class RetryTest(HSTestCase):
         self.mock_api(method=POST, callback=callback_post)
 
         # Act
-        err = None
-
         job = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
         job.metadata['foo'] = 'bar'
         job.metadata.save()
 
         # Assert
-        self.assertIsNone(err, None)
         self.assertEqual(attempts_count_post[0], 3)
 
     @responses.activate
@@ -172,7 +166,8 @@ class RetryTest(HSTestCase):
             err = e
 
         # Assert
-        self.assertIsNone(job, None)
+        self.assertIsNone(job)
+        self.assertIsNotNone(err)
         self.assertEqual(err.response.status_code, 504)
         self.assertEqual(attempts_count[0], 1)
 
@@ -210,7 +205,8 @@ class RetryTest(HSTestCase):
             err = e
 
         # Assert
-        self.assertIsNone(metadata, None)
+        self.assertIsNone(metadata)
+        self.assertIsNotNone(err)
         self.assertEqual(err.response.status_code, 504)
         self.assertEqual(attempts_count[0], 1)
 
@@ -232,7 +228,8 @@ class RetryTest(HSTestCase):
             err = e
 
         # Assert
-        self.assertIsNone(metadata, None)
+        self.assertIsNone(metadata)
+        self.assertIsNotNone(err)
         self.assertEqual(err.response.status_code, 504)
         self.assertEqual(attempts_count[0], 3)
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,6 +1,7 @@
 """
 Test Retry Policy
 """
+from requests import HTTPError
 from hstestcase import HSTestCase
 from hubstorage import HubstorageClient
 import responses
@@ -10,32 +11,94 @@ import re
 
 class RetryTest(HSTestCase):
     @responses.activate
-    def test_retry_get_job(self):
+    def test_get_job_does_retry(self):
         # Prepare
         client = HubstorageClient(auth=self.auth, endpoint=self.endpoint, max_retries=3)
         job_metadata = {'project': self.projectid, 'spider': self.spidername, 'state': 'pending'}
+        callback, attempts_count = self.make_request_callback(2, job_metadata)
 
-        # setup connector that fails on 2 calls
+        responses.add_callback(
+            responses.GET, re.compile(self.endpoint + '/.*'),
+            callback=callback,
+            content_type='application/json',
+        )
+
+        # Act
+        job = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
+
+        # Assert
+        self.assertEqual(dict(job_metadata), dict(job.metadata))
+        self.assertEqual(attempts_count[0], 3)
+
+    @responses.activate
+    def test_get_job_does_fails_if_no_retries(self):
+        # Prepare
+        client = HubstorageClient(auth=self.auth, endpoint=self.endpoint, max_retries=0)
+        job_metadata = {'project': self.projectid, 'spider': self.spidername, 'state': 'pending'}
+        callback, attempts_count = self.make_request_callback(2, job_metadata)
+
+        responses.add_callback(
+            responses.GET, re.compile(self.endpoint + '/.*'),
+            callback=callback,
+            content_type='application/json',
+        )
+
+        # Act
+        job, metadata, err = None, None, None
+        try:
+            job = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
+            metadata = dict(job.metadata)
+        except HTTPError as e:
+            err = e
+
+        # Assert
+        self.assertIsNone(metadata, None)
+        self.assertEqual(err.response.status_code, 504)
+        self.assertEqual(attempts_count[0], 1)
+
+    @responses.activate
+    def test_get_job_does_fails_on_too_many_retries(self):
+        # Prepare
+        client = HubstorageClient(auth=self.auth, endpoint=self.endpoint, max_retries=2)
+        job_metadata = {'project': self.projectid, 'spider': self.spidername, 'state': 'pending'}
+        callback, attempts_count = self.make_request_callback(3, job_metadata)
+
+        responses.add_callback(
+            responses.GET, re.compile(self.endpoint + '/.*'),
+            callback=callback,
+            content_type='application/json',
+        )
+
+        # Act
+        job, metadata, err = None, None, None
+        try:
+            job = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
+            metadata = dict(job.metadata)
+        except HTTPError as e:
+            err = e
+
+        # Assert
+        self.assertIsNone(metadata, None)
+        self.assertEqual(err.response.status_code, 504)
+        self.assertEqual(attempts_count[0], 3)
+
+    def make_request_callback(self, timeout_count, body_on_success):
+        """
+        Make a request callback that timeout a couple of time before returning body_on_success
+
+        Returns:
+            A tuple (request_callback, attempts), attempts is an array of size one that contains the number of time
+            request_callback has been called.
+        """
         attempts = [0]  # use a list for nonlocal mutability used in request_callback
 
         def request_callback(request):
             attempts[0] += 1
 
-            if attempts[0] < 3:
+            if attempts[0] <= timeout_count:
                 return (504, {}, "Timeout")
             else:
-                resp_body = dict(job_metadata)
+                resp_body = dict(body_on_success)
                 return (200, {}, json.dumps(resp_body))
 
-        responses.add_callback(
-            responses.GET, re.compile(self.endpoint + '/.*'),
-            callback=request_callback,
-            content_type='application/json',
-        )
-
-        # Act
-        job2 = client.get_job('%s/%s/%s' % (self.projectid, self.spiderid, 42))
-
-        # Assert
-        self.assertEqual(dict(job_metadata), dict(job2.metadata))
-        self.assertEqual(attempts[0], 3)
+        return (request_callback, attempts)

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, py33
+envlist = py27, pypy, py3
 
 [testenv]
 deps =
     -rrequirements.txt
+    responses==0.5.0
     nose
+
 commands = nosetests []


### PR DESCRIPTION
Add a retry policy to idempotent requests (GET, DELETE, POST that sets data),

- default `max_retries` to 3 so that users automatically benefit from this change.
- Catches server errors: 429 (too many requests), 503 (service unavailable), 504 (timeout) and BadStatusLine errors (remote disconnected)

Add dependency to `responses` library for testing (mock the `requests` library).