### PR TITLE
hubstorage improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.pyc
+*.sw*
+.tox
+*egg-info
+build
+dist

--- a/hubstorage/job.py
+++ b/hubstorage/job.py
@@ -29,7 +29,7 @@ class Job(object):
         for w in wl:
             w.close(block=True)
 
-    def _update_metadata(self, *args, **kwargs):
+    def update_metadata(self, *args, **kwargs):
         self.metadata.update(*args, **kwargs)
         self.metadata.save()
         self.metadata.expire()
@@ -41,7 +41,7 @@ class Job(object):
         self.metadata.expire()
         close_reason = close_reason or \
             self.metadata.liveget('close_reason') or 'no_reason'
-        self._update_metadata(close_reason=close_reason)
+        self.update_metadata(close_reason=close_reason)
         self.close_writers()
         self.jobq.finish(self)
 
@@ -53,9 +53,6 @@ class Job(object):
     def purged(self):
         self.jobq.delete(self)
         self.metadata.expire()
-
-    def stop(self):
-        self._update_metadata(stop_requested=True)
 
 
 class JobMeta(MappingResourceType):

--- a/hubstorage/project.py
+++ b/hubstorage/project.py
@@ -4,7 +4,7 @@ from .activity import Activity
 from .collectionsrt import Collections
 from .frontier import Frontier
 from .resourcetype import ResourceType, MappingResourceType
-from .utils import urlpathjoin, xauth
+from .utils import urlpathjoin, xauth, deprecation
 
 
 class Project(object):
@@ -43,6 +43,8 @@ class Project(object):
         return self.client.get_job(key, *args, **kwargs)
 
     def get_jobs(self, **kwargs):
+        deprecation('Method `project.get_jobs()` is deprecated, '
+                    'use `project.jobq.list()` instead')
         for metadata in self.jobq.list(**kwargs):
             key = metadata.pop('key')
             yield self.get_job(key, metadata=metadata)
@@ -111,10 +113,6 @@ class Reports(ResourceType):
 
     resource_type = 'projects'
     key_suffix = 'reports'
-
-    def usagestats(self, **params):
-        r = self.apiget('usagestats', params=params)
-        return r.next()
 
 
 class Spiders(ResourceType):

--- a/hubstorage/project.py
+++ b/hubstorage/project.py
@@ -1,10 +1,12 @@
+import warnings
+
 from .job import Job
 from .jobq import JobQ
 from .activity import Activity
 from .collectionsrt import Collections
 from .frontier import Frontier
 from .resourcetype import ResourceType, MappingResourceType
-from .utils import urlpathjoin, xauth, deprecation
+from .utils import urlpathjoin, xauth
 
 
 class Project(object):
@@ -43,8 +45,8 @@ class Project(object):
         return self.client.get_job(key, *args, **kwargs)
 
     def get_jobs(self, **kwargs):
-        deprecation('Method `project.get_jobs()` is deprecated, '
-                    'use `project.jobq.list()` instead')
+        warnings.warn('Method `project.get_jobs()` is deprecated, '
+                      'use `project.jobq.list()` instead', Warning)
         for metadata in self.jobq.list(**kwargs):
             key = metadata.pop('key')
             yield self.get_job(key, metadata=metadata)

--- a/hubstorage/resourcetype.py
+++ b/hubstorage/resourcetype.py
@@ -166,6 +166,12 @@ class MappingResourceType(ResourceType, MutableMapping):
         self._deleted = set()
         super(MappingResourceType, self).__init__(*a, **kw)
 
+    def __str__(self):
+        return str(self._data)
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, repr(self._data))
+
     @property
     def _data(self):
         if self._cached is None:

--- a/hubstorage/utils.py
+++ b/hubstorage/utils.py
@@ -1,5 +1,4 @@
 import time
-import warnings
 from Queue import Empty
 
 
@@ -133,5 +132,3 @@ def apipoll(endpoint, *args, **kwargs):
         if result is not None or (time.time() - start) > max_poll:
             return result
 
-def deprecation(message):
-    warnings.warn(message, Warning, stacklevel=2)

--- a/hubstorage/utils.py
+++ b/hubstorage/utils.py
@@ -1,4 +1,5 @@
 import time
+import warnings
 from Queue import Empty
 
 
@@ -131,3 +132,6 @@ def apipoll(endpoint, *args, **kwargs):
         result = endpoint(*args, **kwargs)
         if result is not None or (time.time() - start) > max_poll:
             return result
+
+def deprecation(message):
+    warnings.warn(message, Warning, stacklevel=2)

--- a/tests/test_jobsmeta.py
+++ b/tests/test_jobsmeta.py
@@ -59,6 +59,31 @@ class JobsMetadataTest(HSTestCase):
         job2 = self.hsclient.get_job(job.key)
         self._assertMetadata(job.metadata, job2.metadata)
 
+    def test_updating(self):
+        job = self.project.push_job(self.spidername)
+        self.assertIsNone(job.metadata.get('foo'))
+        job.update_metadata({'foo': 'bar'})
+        # metadata attr should change
+        self.assertEqual(job.metadata.get('foo'), 'bar')
+        # as well as actual metadata
+        job = self.project.get_job(job.key)
+        self.assertEqual(job.metadata.get('foo'), 'bar')
+        job.update_metadata({'foo': None})
+        self.assertFalse(job.metadata.get('foo', False))
+
+        # there are ignored fields like: auth, _key, state
+        state = job.metadata['state']
+        job.update_metadata({'state': 'running'})
+        self.assertEqual(job.metadata['state'], state)
+
+    def test_representation(self):
+        job = self.project.push_job(self.spidername)
+        meta = job.metadata
+        self.assertNotEqual(str(meta), repr(meta))
+        self.assertEqual(meta, eval(str(meta)))
+        self.assertTrue(meta.__class__.__name__ in repr(meta))
+        self.assertFalse(meta.__class__.__name__ in str(meta))
+
     def test_jobauth(self):
         job = self.project.push_job(self.spidername)
         self.assertIsNone(job.jobauth)


### PR DESCRIPTION
- repr & str view for MappingResourceType
- remove obsolete job.stop() method
- deprecation warning for using project.get_jobs()
- visible job.update_metadata() method
- remove project.reports.usagestats() (broken usagestats/stats endpoint)