### PR TITLE
Move job's low level methods to tests only

### DIFF
--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -152,23 +152,6 @@ class HubstorageClient(object):
         project = self.projects.get(projectid, auth=auth)
         return project.push_job(spidername, **jobparams)
 
-    def start_job(self, projectid=None, auth=None, **startparams):
-        """Start a new job
-
-        It may take up to a second for a previously added job to be available
-        here if no project id is specified.
-
-        """
-        if projectid:
-            jobq = self.projects.get(projectid, auth=auth).jobq
-        else:
-            jobq = self.jobq
-        jobdata = jobq.start(**startparams)
-        if jobdata:
-            jobkey = jobdata.pop('key')
-            jobauth = (jobkey, jobdata['auth'])
-            return self.get_job(jobkey, jobauth=jobauth, metadata=jobdata)
-
     def get_project(self, *args, **kwargs):
         return self.projects.get(*args, **kwargs)
 

--- a/hubstorage/job.py
+++ b/hubstorage/job.py
@@ -20,6 +20,15 @@ class Job(object):
         self.requests = Requests(client, self.key, self.auth)
         self.jobq = JobQ(client, self.key.split('/')[0], auth)
 
+    def close_writers(self):
+        wl = [self.items, self.logs, self.samples, self.requests]
+        # close all resources that use background writers
+        for w in wl:
+            w.close(block=False)
+        # now wait for all writers to close together
+        for w in wl:
+            w.close(block=True)
+
     def update_metadata(self, *args, **kwargs):
         self.metadata.update(*args, **kwargs)
         self.metadata.save()

--- a/hubstorage/jobq.py
+++ b/hubstorage/jobq.py
@@ -101,7 +101,7 @@ class JobQ(ResourceType):
         It may take up to a second for a previously added job to be available.
         """
         if job:
-            return self._set_state(job, 'running', **start_params)
+            return self.update(job, state='running', **start_params)
         for o in self.apipost('startjob', jl=start_params):
             return o
 
@@ -109,11 +109,11 @@ class JobQ(ResourceType):
         """Cancel a running job"""
         self.apipost("%s/cancel" % job.key[job.key.index('/') + 1:])
 
-    def finish(self, job):
-        return self._set_state(job, 'finished')
+    def finish(self, job, **params):
+        return self.update(job, state='finished', **params)
 
-    def delete(self, job):
-        return self._set_state(job, 'deleted')
+    def delete(self, job, **params):
+        return self.update(job, state='deleted', **params)
 
     def _jobkeys(self, job):
         if isinstance(job, list):
@@ -127,6 +127,6 @@ class JobQ(ResourceType):
         else:
             yield job
 
-    def _set_state(self, job, state, **extra_args):
-        data = [dict(extra_args, key=k, state=state) for k in self._jobkeys(job)]
+    def update(self, job, **extra_args):
+        data = [dict(extra_args, key=k) for k in self._jobkeys(job)]
         return self.apipost('update', jl=data)

--- a/hubstorage/project.py
+++ b/hubstorage/project.py
@@ -56,10 +56,6 @@ class Project(object):
         key = data['key']
         return Job(self.client, key, auth=self.auth)
 
-    def start_job(self, **startparams):
-        return self.client.start_job(projectid=self.projectid, auth=self.auth,
-            **startparams)
-
     def jobsummary(self, **params):
         uri = ('projects', self.projectid, 'jobsummary')
         return next(self.client.root.apiget(uri, auth=self.auth, params=params))

--- a/tests/hstestcase.py
+++ b/tests/hstestcase.py
@@ -71,6 +71,33 @@ class HSTestCase(unittest.TestCase):
         cls.project.settings.apidelete('botgroups')
         cls.project.settings.expire()
 
+    def start_job(self, **startparams):
+        jobdata = self.project.jobq.start(**startparams)
+        if jobdata:
+            jobkey = jobdata.pop('key')
+            jobauth = (jobkey, jobdata['auth'])
+            return self.project.get_job(jobkey, jobauth=jobauth, metadata=jobdata)
+
+    def job_finished(self, job, close_reason=None):
+        close_reason = close_reason or \
+            job.metadata.liveget('close_reason') or 'no_reason'
+        self.close_job_writers(job)
+        job.jobq.finish(job, close_reason=close_reason)
+
+    def job_failed(self, job, reason='failed', message=None):
+        if message:
+            job.logs.error(message, appendmode=True)
+        self.job_finished(job, reason)
+
+    def close_job_writers(self, job):
+        wl = [job.items, job.logs, job.samples, job.requests]
+        # close all resources that use background writers
+        for w in wl:
+            w.close(block=False)
+        # now wait for all writers to close together
+        for w in wl:
+            w.close(block=True)
+
 
 class NopTest(HSTestCase):
 

--- a/tests/hstestcase.py
+++ b/tests/hstestcase.py
@@ -78,26 +78,6 @@ class HSTestCase(unittest.TestCase):
             jobauth = (jobkey, jobdata['auth'])
             return self.project.get_job(jobkey, jobauth=jobauth, metadata=jobdata)
 
-    def job_finished(self, job, close_reason=None):
-        close_reason = close_reason or \
-            job.metadata.liveget('close_reason') or 'no_reason'
-        self.close_job_writers(job)
-        job.jobq.finish(job, close_reason=close_reason)
-
-    def job_failed(self, job, reason='failed', message=None):
-        if message:
-            job.logs.error(message, appendmode=True)
-        self.job_finished(job, reason)
-
-    def close_job_writers(self, job):
-        wl = [job.items, job.logs, job.samples, job.requests]
-        # close all resources that use background writers
-        for w in wl:
-            w.close(block=False)
-        # now wait for all writers to close together
-        for w in wl:
-            w.close(block=True)
-
 
 class NopTest(HSTestCase):
 

--- a/tests/test_batchuploader.py
+++ b/tests/test_batchuploader.py
@@ -11,7 +11,7 @@ class BatchUploaderTest(HSTestCase):
 
     def _job_and_writer(self, **writerargs):
         self.project.push_job(self.spidername)
-        job = self.project.start_job()
+        job = self.start_job()
         bu = self.hsclient.batchuploader
         w = bu.create_writer(job.items.url, auth=self.auth, **writerargs)
         return job, w

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ class ClientTest(HSTestCase):
         c.push_job(self.projectid, self.spidername,
                    priority=self.project.jobq.PRIO_LOW,
                    foo='baz')
-        job = c.start_job(projectid=self.projectid)
+        job = self.start_job()
         m = job.metadata
         self.assertEqual(m.get('state'), u'running', c.auth)
         self.assertEqual(m.get('foo'), u'baz')
@@ -21,36 +21,6 @@ class ClientTest(HSTestCase):
         m = c.get_job(job.key).metadata
         self.assertEqual(m.get('state'), u'deleted')
         self.assertEqual(m.get('foo'), u'baz')
-
-    def test_botgroup(self):
-        self.project.settings.update(botgroups=['foo'], created=millitime())
-        self.project.settings.save()
-        c = self.hsclient
-        q1 = c.push_job(self.project.projectid, self.spidername)
-        j1 = c.start_job()
-        self.assertEqual(j1, None, 'got %s, pushed job was %s' % (j1, q1))
-        j2 = c.start_job(botgroup='bar')
-        self.assertEqual(j2, None, 'got %s, pushed job was %s' % (j2, q1))
-        j3 = apipoll(self.hsclient.start_job, botgroup='foo')
-        self.assertEqual(j3.key, q1.key)
-
-    def test_start_job(self):
-        # Pending queue is empty
-        job = self.hsclient.start_job(botgroup=self.testbotgroup)
-        self.assertEqual(job, None)
-        # Push a new job into pending queue
-        j0 = self.hsclient.push_job(self.projectid, self.spidername)
-        # Assert it is pending
-        self.assertEqual(j0.metadata.get('state'), 'pending')
-        # Poll for the pending job
-        j1 = apipoll(self.hsclient.start_job, botgroup=self.testbotgroup)
-        # Assert started job does not need an extra request to fetch its metadata
-        self.assertTrue(j1.metadata._cached is not None)
-        # Assert started job is in running queue
-        self.assertEqual(j1.metadata.get('state'), 'running')
-        # Started job metadata must match metadata retrieved directly from /jobs/
-        j2 = self.hsclient.get_job(j1.key)
-        self.assertEqual(dict(j1.metadata), dict(j2.metadata))
 
     def test_jobsummaries(self):
         hsc = self.hsclient

--- a/tests/test_jobq.py
+++ b/tests/test_jobq.py
@@ -319,6 +319,14 @@ class JobqTest(HSTestCase):
         self.assertTrue([x['prevstate'] for x in jobq.delete(ids)],
                         ['finished', 'finished', 'finished'])
 
+    def test_update(self):
+        job = self.project.push_job(self.spidername)
+        self.assertEqual(job.metadata['state'], 'pending')
+        self.project.jobq.update(job, state='running', foo='bar')
+        job = self.project.get_job(job.key)
+        self.assertEqual(job.metadata['state'], 'running')
+        self.assertEqual(job.metadata['foo'], 'bar')
+
 
 def _keys(lst):
     return [x['key'] for x in lst]

--- a/tests/test_jobsmeta.py
+++ b/tests/test_jobsmeta.py
@@ -97,7 +97,7 @@ class JobsMetadataTest(HSTestCase):
 
     def test_authtoken(self):
         pendingjob = self.project.push_job(self.spidername)
-        runningjob = self.project.start_job()
+        runningjob = self.start_job()
         self.assertEqual(pendingjob.key, runningjob.key)
         self.assertTrue(runningjob.jobauth)
         self.assertEqual(runningjob.jobauth, runningjob.auth)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -121,12 +121,12 @@ class ProjectTest(HSTestCase):
         # populate project with at least one job
         job = project.push_job(self.spidername)
         self.assertEqual(job.metadata.get('state'), 'pending')
-        job = project.start_job()
+        job = self.start_job()
         self.assertEqual(job.metadata.get('state'), 'running')
         job.items.write({'title': 'bar'})
         job.logs.info('nice to meet you')
         job.samples.write([1, 2, 3])
-        job.finished()
+        self.job_finished(job)
 
         # keep a jobid for get_job and unreference job
         jobid = job.key
@@ -169,7 +169,7 @@ class ProjectTest(HSTestCase):
         r3 = job.requests.add(url='http://test.com/3', status=400, method='PUT',
                               rs=0, duration=1, parent=r1, ts=ts + 2, fp='1234')
 
-        job.close_writers()
+        self.close_job_writers(job)
         rr = job.requests.list()
         self.assertEqual(rr.next(),
                          {u'status': 200, u'rs': 1337,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -126,7 +126,8 @@ class ProjectTest(HSTestCase):
         job.items.write({'title': 'bar'})
         job.logs.info('nice to meet you')
         job.samples.write([1, 2, 3])
-        self.job_finished(job)
+        job.close_writers()
+        job.jobq.finish(job)
 
         # keep a jobid for get_job and unreference job
         jobid = job.key
@@ -169,7 +170,7 @@ class ProjectTest(HSTestCase):
         r3 = job.requests.add(url='http://test.com/3', status=400, method='PUT',
                               rs=0, duration=1, parent=r1, ts=ts + 2, fp='1234')
 
-        self.close_job_writers(job)
+        job.requests.close()
         rr = job.requests.list()
         self.assertEqual(rr.next(),
                          {u'status': 200, u'rs': 1337,

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -64,12 +64,14 @@ class SystemTest(HSTestCase):
             try:
                 self._run_scraper(job.key, job.jobauth, close_reason=close_reason)
             except Exception as exc:
-                self.job_failed(job, message=str(exc))
+                job.logs.error(message=str(exc), appendmode=True)
+                job.close_writers()
+                job.jobq.finish(job, close_reason='failed')
                 # logging from runner must append and never remove messages logged
                 # by scraper
                 self.assertTrue(job.logs.batch_append)
             else:
-                self.job_finished(job)
+                job.jobq.finish(job, close_reason=close_reason or 'no_reason')
 
     def _run_scraper(self, jobkey, jobauth, close_reason=None):
         httpmethods = 'GET PUT POST DELETE HEAD OPTIONS TRACE CONNECT'.split()

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -56,7 +56,7 @@ class SystemTest(HSTestCase):
     def _run_runner(self, pushed, close_reason):
         client = HubstorageClient(endpoint=self.endpoint, auth=self.auth)
         with closing(client) as runnerclient:
-            job = runnerclient.start_job(self.projectid)
+            job = self.start_job()
             self.assertFalse(job.metadata.get('stop_requested'))
             job.metadata.update(host='localhost', slot=1)
             self.assertEqual(job.metadata.get('state'), 'running')
@@ -64,12 +64,12 @@ class SystemTest(HSTestCase):
             try:
                 self._run_scraper(job.key, job.jobauth, close_reason=close_reason)
             except Exception as exc:
-                job.failed(message=str(exc))
+                self.job_failed(job, message=str(exc))
                 # logging from runner must append and never remove messages logged
                 # by scraper
                 self.assertTrue(job.logs.batch_append)
             else:
-                job.finished()
+                self.job_finished(job)
 
     def _run_scraper(self, jobkey, jobauth, close_reason=None):
         httpmethods = 'GET PUT POST DELETE HEAD OPTIONS TRACE CONNECT'.split()


### PR DESCRIPTION
- move low level methods to basic testcase, like:

```
project.start_job/client.start_job -> start_job,
job.finished -> expand to jobq.finish(),
job.failed -> expand to jobq.finish(),
```
- jobq._set_state -> jobq.update()
- add tests for jobq.update()