### PR TITLE
Fail creating a collection with an invalid name

### DIFF
--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -99,3 +99,12 @@ class CollectionsTest(HSTestCase):
         with failing_downloader(self.project.collections):
             downloaded = list(col.iter_values(start='test_data_download1'))
             self.assertEqual(len(downloaded), 19)
+
+    def test_invalid_collection_name(self):
+        cols = self.project.collections
+        self.assertRaises(ValueError, cols.new_collection, 'invalidtype', 'n')
+        self.assertRaises(ValueError, cols.new_store, 'foo-bar')
+        self.assertRaises(ValueError, cols.new_store, 'foo/bar')
+        self.assertRaises(ValueError, cols.new_store, '/foo')
+        self.assertRaises(ValueError, cols.create_writer, 'invalidtype', 'n')
+        self.assertRaises(ValueError, cols.create_writer, 's', 'foo-bar')


### PR DESCRIPTION
```
$ tox -- tests/test_collections.py
GLOB sdist-make: /Users/daniel/src/python-hubstorage/setup.py
py27 inst-nodeps:
/Users/daniel/src/python-hubstorage/.tox/dist/hubstorage-0.20.0.zip
py27 installed:
cookies==2.2.1,funcsigs==0.4,hubstorage==0.20.0,mock==1.3.0,nose==1.3.7,pbr==1.8.1,requests==2.9.1,responses==0.5.0,retrying==1.3.3,six==1.10.0,wheel==0.24.0
py27 runtests: PYTHONHASHSEED='4179262623'
py27 runtests: commands[0] | nosetests tests/test_collections.py
nose.config: INFO: Ignoring files matching ['^\\.', '^_',
'^setup\\.py$']
post_get_delete_test (tests.test_collections.CollectionsTest) ... ok
post_scan_test (tests.test_collections.CollectionsTest) ... ok
test_data_download (tests.test_collections.CollectionsTest) ... ok
test_errors (tests.test_collections.CollectionsTest) ... ok
test_invalid_collection_name (tests.test_collections.CollectionsTest)
... ok

----------------------------------------------------------------------
Ran 5 tests in 13.061s

OK
```