### PR TITLE
Add support for listing collections endpoint

### DIFF
--- a/hubstorage/collectionsrt.py
+++ b/hubstorage/collectionsrt.py
@@ -20,6 +20,9 @@ class Collections(DownloadableResource):
             else:
                 raise
 
+    def list(self):
+        return self.apiget('list')
+
     def set(self, _type, _name, _values):
         try:
             return self.apipost((_type, _name), is_idempotent=True, jl=_values)


### PR DESCRIPTION
Hey fellows,
This adds support for the listing collections endpoint:

```
>>> from hubstorage import HubstorageClient
>>> import os
>>> apikey = os.getenv('SHUB_APIKEY')
>>> list(HubstorageClient(apikey).get_project(30172).collections.list())
[{u'name': u'bwalk_properties', u'type': u's'},
 {u'name': u'linkedin_companies', u'type': u's'}]
```

Does this look good?
Thanks!