### PR TITLE
Making only 1 call to Response.raise_for_status

### DIFF
--- a/hubstorage/client.py
+++ b/hubstorage/client.py
@@ -88,10 +88,12 @@ class HubstorageClient(object):
         def invoke_request():
             r = self.session.request(**kwargs)
 
-            if not r.ok:
+            try:
+                r.raise_for_status()
+                return r
+            except HTTPError:
                 logger.debug('%s: %s', r, r.content)
-            r.raise_for_status()
-            return r
+                raise
 
         if is_idempotent:
             return self.retrier.call(invoke_request)


### PR DESCRIPTION
Response.ok invokes raise_for_status under the hood so there is no need to call the same method twice.
Probably the previous code looked a bit neater but doing the same check once again looks superfluous to me.