### PR TITLE
Add Job.jobsummary method to fetch metadata for multiple jobs

### DIFF
--- a/hubstorage/jobq.py
+++ b/hubstorage/jobq.py
@@ -31,6 +31,13 @@ class JobQ(ResourceType):
                 raise DuplicateJobError()
             raise
 
+    def jobsummary(self, jobkeys, jobmeta):
+        """Fetch selected job metadata fields for selected jobs."""
+        if not isinstance(jobkeys, (list, tuple)):
+            raise TypeError("jobkeys must be a list or a tuple")
+        return self.apiget(('jobsummary',),
+                           params={'key': jobkeys, 'jobmeta': jobmeta})
+
     def summary(self, _queuename=None, spiderid=None, count=None, start=None, jobmeta=None):
         params = {}
         if count is not None:

--- a/tests/test_jobq.py
+++ b/tests/test_jobq.py
@@ -327,6 +327,17 @@ class JobqTest(HSTestCase):
         self.assertEqual(job.metadata['state'], 'running')
         self.assertEqual(job.metadata['foo'], 'bar')
 
+    def test_jobsummary(self):
+        jobs = [self.project.push_job(self.spidername, foo=i)
+                for i in range(5)]
+        jobmetas = list(self.project.jobq.jobsummary(
+            jobkeys=[j.key for j in jobs], jobmeta=['key', 'foo']))
+        jobmeta_dict = {jm['key']: jm['foo'] for jm in jobmetas}
+        assert jobmeta_dict == {
+            jobs[i].key: i
+            for i in range(5)
+        }
+
 
 def _keys(lst):
     return [x['key'] for x in lst]


### PR DESCRIPTION
It should reduce number of jobq requests in batch-like workloads.