### PR TITLE
Fix unit tests calling jobq.delete()

### DIFF
--- a/tests/hstestcase.py
+++ b/tests/hstestcase.py
@@ -55,6 +55,7 @@ class HSTestCase(unittest.TestCase):
 
     @classmethod
     def _remove_job(cls, jobkey):
+        cls.project.jobq.finish(jobkey)
         cls.project.jobq.delete(jobkey)
         cls._delete_job(jobkey)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,7 @@ class ClientTest(HSTestCase):
         m = job.metadata
         self.assertEqual(m.get('state'), u'running', c.auth)
         self.assertEqual(m.get('foo'), u'baz')
+        self.project.jobq.finish(job)
         self.project.jobq.delete(job)
 
         # job auth token is valid only while job is running

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -69,6 +69,7 @@ class ProjectTest(HSTestCase):
                                    foo=u'bar')
         self.assertEqual(job.metadata.get('state'), u'running')
         self.assertEqual(job.metadata.get('foo'), u'bar')
+        self.project.jobq.finish(job)
         self.project.jobq.delete(job)
         job.metadata.expire()
         self.assertEqual(job.metadata.get('state'), u'deleted')


### PR DESCRIPTION
Now JobQ returns HTTP status 400 if client tries to delete non-`finished` jobs.